### PR TITLE
Allow webcam sleep duration to be set in config

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -17,6 +17,7 @@ pub enum Als {
     },
     Webcam {
         video: usize,
+        sleep_ms: Option<u64>,
         thresholds: HashMap<u64, String>,
     },
     None,

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -20,6 +20,7 @@ pub enum Als {
     },
     Webcam {
         video: usize,
+        sleep_ms: Option<u64>,
         thresholds: HashMap<String, String>,
     },
     None,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,8 +64,13 @@ fn parse() -> Result<app::Config, toml::de::Error> {
                 path,
                 thresholds: parse_als_thresholds(thresholds),
             },
-            file::Als::Webcam { video, thresholds } => app::Als::Webcam {
+            file::Als::Webcam {
                 video,
+                sleep_ms,
+                thresholds,
+            } => app::Als::Webcam {
+                video,
+                sleep_ms,
                 thresholds: parse_als_thresholds(thresholds),
             },
             file::Als::Time { thresholds } => app::Als::Time {

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,12 +112,12 @@ fn main() {
                         .expect("Unable to initialize ALS IIO sensor"),
                 ),
                 config::Als::Time { thresholds } => Box::new(als::time::Als::new(thresholds)),
-                config::Als::Webcam { video, thresholds } => Box::new({
+                config::Als::Webcam { video, thresholds, sleep_ms } => Box::new({
                     let (webcam_tx, webcam_rx) = mpsc::channel();
                     std::thread::Builder::new()
                         .name("als-webcam".to_string())
                         .spawn(move || {
-                            als::webcam::Webcam::new(webcam_tx, video).run();
+                            als::webcam::Webcam::new(webcam_tx, video, sleep_ms).run();
                         })
                         .expect("Unable to start thread: als-webcam");
                     als::webcam::Als::new(webcam_rx, thresholds)


### PR DESCRIPTION
My laptop has a webcam activity LED and I got annoyed with it flashing every 2 seconds.  

This allows setting the delay between steps instead of using the `WAITING_SLEEP_MS` constant. If it is not set or a value < `MIN_WAITING_SLEEP_MS` is passed, `WAITING_SLEEP_MS` is used as a default.

I used 1000ms for `MIN_WAITING_SLEEP_MS`, not sure if its even needed but I assume no one wants to use less than that...

An example:
```toml
[als.webcam]
video = 0
sleep_ms = 5000
thresholds = { 0 = "night", 15 = "dark", 30 = "dim", 45 = "normal", 60 = "bright", 75 = "outdoors" }
```

I added tests for no custom value, an invalid custom value and a valid custom value in which I am passing `0` as the `video` parameter in the `Webcam` constructor, let me know if this needs to change.

This is my first time working with Rust, so any feedback/improvements would be appreciated :smile: 