### PR TITLE
Decouple DDC Capture Identity and improve DDC resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,11 @@ Each of them contains a `thresholds` field, which comes with good default values
 
 Multiple outputs are supported, using `backlight` (common for internal laptop screens) and `ddcutil` (for external screens). DDC is known to often be problematic, always consider trying out [ddcci-driver-linux](https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux) first if you can.
 
-When `capturer="wayland"` is used, wluma matches compositor outputs by their model, manufacturer and serial number (e.g.`eDP-1 'Sharp Corporation 0x14A8 0x00000000' (eDP-1)`).
-
-The `name` field in the output config identifies the Wayland output and the predictor data. It is matched as a substring against Wayland output descriptions, so you are free to put simply `eDP-1`, `HDMI-A-3`, or a unique model/serial substring. It is your responsibility to make sure that the values you use match **uniquely** to one output only.
+The `name` field in the output config identifies the Wayland output, and is matched as a substring against descriptions containing model, manufacturer and serial number (like `eDP-1 'Sharp Corporation 0x14A8 0x00000000' (eDP-1)`), so you are free to put simply `eDP-1`, `HDMI-A-3`, or a unique model/serial substring. It is your responsibility to make sure that the values you use match **uniquely** to one output only.
 
 For `output.ddcutil`, if the identifier that works for brightness control is not the same substring that your Wayland compositor exposes for screen capture, set `identifier`. This is common for external DDC monitors: `name` should match the compositor output description such as `HDMI-A-3` or `LG ULTRAWIDE`, while `identifier` may need to be a serial number for DDC.
 
-_Tip:_ run `wluma` with `RUST_LOG=debug` to see how your outputs are being identified, so that you can choose an appropriate `name` configuration value.
+_Tip:_ run `wluma` with `RUST_LOG=debug` to see how your outputs are being identified, so that you can choose an appropriate `name` and `identifier` configuration values.
 
 The `capturer` field will determine how screen contents will be captured. Currently supported values are `wayland` (works only on Wayland compositors that support protocols listed in the top) and `none` (ignores screen contents and predicts brightness only based on ALS). The value `wayland` will automatically choose the most appropriate protocol, but if you want to force a specific one, you can also use `ext-image-capture-source-v1`, `wlr-screencopy-unstable-v1` or `wlr-export-dmabuf-unstable-v1` as the value.
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ Each of them contains a `thresholds` field, which comes with good default values
 
 Multiple outputs are supported, using `backlight` (common for internal laptop screens) and `ddcutil` (for external screens). DDC is known to often be problematic, always consider trying out [ddcci-driver-linux](https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux) first if you can.
 
-Each output is identified by compositor using model, manufacturer and serial number (e.g.`eDP-1 'Sharp Corporation 0x14A8 0x00000000' (eDP-1)`.
+When `capturer="wayland"` is used, wluma matches compositor outputs by their model, manufacturer and serial number (e.g.`eDP-1 'Sharp Corporation 0x14A8 0x00000000' (eDP-1)`).
 
-The `name` field in the output config will be matched as a substring, so you are free to put simply `eDP-1`, or a serial number (if you have two identical external screens). It is your responsibility to make sure that the values you use match **uniquely** to one output only.
+The `name` field in the output config identifies the Wayland output and the predictor data. It is matched as a substring against Wayland output descriptions, so you are free to put simply `eDP-1`, `HDMI-A-3`, or a unique model/serial substring. It is your responsibility to make sure that the values you use match **uniquely** to one output only.
+
+For `output.ddcutil`, if the identifier that works for brightness control is not the same substring that your Wayland compositor exposes for screen capture, set `identifier`. This is common for external DDC monitors: `name` should match the compositor output description such as `HDMI-A-3` or `LG ULTRAWIDE`, while `identifier` may need to be a serial number for DDC.
 
 _Tip:_ run `wluma` with `RUST_LOG=debug` to see how your outputs are being identified, so that you can choose an appropriate `name` configuration value.
 

--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,8 @@ path = "/sys/class/backlight/intel_backlight"
 capturer = "wayland"
 
 # [[output.ddcutil]]
-# name = "Dell Inc. DELL P2415Q"
+# name = "HDMI-A-3"
+# identifier = "Dell Inc. DELL P2415Q"
 # capturer = "none"
 
 [[keyboard]]

--- a/src/brightness/controller.rs
+++ b/src/brightness/controller.rs
@@ -8,8 +8,6 @@ use std::thread;
 use std::time::Duration;
 
 const TRANSITION_MAX_MS: u64 = 200;
-const TRANSITION_STEP_MS: u64 = 1;
-const WAITING_SLEEP_MS: u64 = 100;
 
 pub struct Controller {
     brightness: Brightness,
@@ -77,7 +75,7 @@ impl Controller {
 
         // 4. nothing to do, sleep and check again
         // TODO: replace with inotify events on brightness device file and avoid sleep loop
-        Timer::after(Duration::from_millis(WAITING_SLEEP_MS)).await;
+        Timer::after(Duration::from_millis(self.brightness.waiting_sleep_ms())).await;
     }
 
     async fn update_current(&mut self, new_brightness: u64) {
@@ -94,10 +92,13 @@ impl Controller {
             (Some(old_target), _) if old_target.desired == desired => (),
             (_, Some(current)) if desired == current => (),
             (_, Some(current)) => {
+                let max_transition_steps = TRANSITION_MAX_MS
+                    .div_ceil(self.brightness.transition_step_ms())
+                    .max(1);
                 let step = if desired > current {
-                    (desired - current).div_ceil(TRANSITION_MAX_MS) as i64
+                    (desired - current).div_ceil(max_transition_steps) as i64
                 } else {
-                    -((current - desired).div_ceil(TRANSITION_MAX_MS) as i64)
+                    -((current - desired).div_ceil(max_transition_steps) as i64)
                 };
                 self.target = Some(Target { desired, step });
             }
@@ -125,7 +126,7 @@ impl Controller {
                             err
                         ),
                     };
-                    thread::sleep(Duration::from_millis(TRANSITION_STEP_MS));
+                    thread::sleep(Duration::from_millis(self.brightness.transition_step_ms()));
                 }
             }
             _ => unreachable!("Current and target values cannot be None at this point"),

--- a/src/brightness/ddcutil.rs
+++ b/src/brightness/ddcutil.rs
@@ -1,8 +1,9 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use ddc_hi::{Ddc, Display, FeatureCode};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use smol::lock::Mutex;
+use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
@@ -11,48 +12,160 @@ lazy_static! {
 }
 
 const DDC_BRIGHTNESS_FEATURE: FeatureCode = 0x10;
-const DDC_WAITING_SLEEP_MS: u64 = 500;
-const DDC_TRANSITION_STEP_MS: u64 = 50;
-const DDC_RETRIES: usize = 3;
-const DDC_RETRY_SLEEP_MS: u64 = 40;
+const DDC_DIRECT_WAITING_SLEEP_MS: u64 = 500;
+const DDC_DIRECT_TRANSITION_STEP_MS: u64 = 50;
+const DDC_CLI_WAITING_SLEEP_MS: u64 = 800;
+const DDC_CLI_TRANSITION_STEP_MS: u64 = 100;
+const DDC_DIRECT_RETRIES: usize = 3;
+const DDC_DIRECT_RETRY_SLEEP_MS: u64 = 40;
+const DDC_CLI_RETRIES: usize = 3;
+const DDC_CLI_RETRY_SLEEP_MS: u64 = 150;
+
+enum Backend {
+    Direct(Box<Mutex<Display>>),
+    Cli { bus: u32 },
+}
 
 pub struct DdcUtil {
-    display: Mutex<Display>,
+    identifier: String,
+    backend: Backend,
     min_brightness: u64,
     max_brightness: u64,
 }
 
 impl DdcUtil {
-    pub fn new(name: &str, min_brightness: u64) -> Result<Self> {
-        let mut display = find_display_by_name(name, true)
-            .or_else(|| find_display_by_name(name, false))
-            .ok_or(anyhow!("Unable to find display"))?;
-        let max_brightness = get_max_brightness_with_retry(&mut display)?;
+    pub fn new(identifier: &str, min_brightness: u64) -> Result<Self> {
+        let direct_error = match find_display_by_identifier(identifier, true)
+            .or_else(|| find_display_by_identifier(identifier, false))
+        {
+            Some(mut display) => match get_max_brightness_with_retry(&mut display) {
+                Ok(max_brightness) => {
+                    return Ok(Self {
+                        identifier: identifier.to_string(),
+                        backend: Backend::Direct(Box::new(Mutex::new(display))),
+                        min_brightness,
+                        max_brightness,
+                    })
+                }
+                Err(err) => {
+                    log::warn!(
+                        "Unable to initialize '{}' with direct DDC access: {:?}. Trying ddcutil CLI fallback.",
+                        identifier,
+                        err
+                    );
+                    err.to_string()
+                }
+            },
+            None => "Unable to find display".to_string(),
+        };
 
-        Ok(Self {
-            display: Mutex::new(display),
-            min_brightness,
-            max_brightness,
-        })
+        let mut cli_backend =
+            Self::new_cli_backend(identifier, min_brightness).map_err(|cli_err| {
+                anyhow!(
+                    "Unable to initialize DDC display '{}' directly ({}) or via ddcutil CLI ({})",
+                    identifier,
+                    direct_error,
+                    cli_err
+                )
+            })?;
+        log::warn!(
+            "Using ddcutil CLI fallback for '{}' because direct DDC access is unreliable on this monitor.",
+            identifier
+        );
+        cli_backend.max_brightness = cli_backend.max_brightness.max(min_brightness);
+        Ok(cli_backend)
     }
 
     pub async fn get(&mut self) -> Result<u64> {
         let _lock = DDC_MUTEX.lock().await;
-        get_brightness_with_retry(self.display.get_mut())
+        match self.get_locked() {
+            Ok(value) => Ok(value),
+            Err(err) if self.switch_to_cli_locked(&err)? => self.get_locked(),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn set(&mut self, value: u64) -> Result<u64> {
         let _lock = DDC_MUTEX.lock().await;
         let value = value.clamp(self.min_brightness, self.max_brightness);
-        set_brightness_with_retry(self.display.get_mut(), value)
+        match self.set_locked(value) {
+            Ok(set_value) => Ok(set_value),
+            Err(err) if self.switch_to_cli_locked(&err)? => self.set_locked(value),
+            Err(err) => Err(err),
+        }
     }
 
     pub fn waiting_sleep_ms(&self) -> u64 {
-        DDC_WAITING_SLEEP_MS
+        match &self.backend {
+            Backend::Direct(_) => DDC_DIRECT_WAITING_SLEEP_MS,
+            Backend::Cli { .. } => DDC_CLI_WAITING_SLEEP_MS,
+        }
     }
 
     pub fn transition_step_ms(&self) -> u64 {
-        DDC_TRANSITION_STEP_MS
+        match &self.backend {
+            Backend::Direct(_) => DDC_DIRECT_TRANSITION_STEP_MS,
+            Backend::Cli { .. } => DDC_CLI_TRANSITION_STEP_MS,
+        }
+    }
+
+    fn new_cli_backend(identifier: &str, min_brightness: u64) -> Result<Self> {
+        let bus = find_ddcutil_bus_by_identifier(identifier)?.ok_or_else(|| {
+            anyhow!(
+                "Unable to find a ddcutil display that matches '{}'",
+                identifier
+            )
+        })?;
+        let (_, max_brightness) = cli_get_brightness(bus)?;
+
+        Ok(Self {
+            identifier: identifier.to_string(),
+            backend: Backend::Cli { bus },
+            min_brightness,
+            max_brightness,
+        })
+    }
+
+    fn get_locked(&mut self) -> Result<u64> {
+        match &mut self.backend {
+            Backend::Direct(display) => get_brightness_with_retry(display.get_mut()),
+            Backend::Cli { bus } => {
+                let (current, max_brightness) = cli_get_brightness(*bus)?;
+                self.max_brightness = max_brightness;
+                Ok(current)
+            }
+        }
+    }
+
+    fn set_locked(&mut self, value: u64) -> Result<u64> {
+        match &mut self.backend {
+            Backend::Direct(display) => set_brightness_with_retry(display.get_mut(), value),
+            Backend::Cli { bus } => {
+                cli_set_brightness(*bus, value)?;
+                Ok(value)
+            }
+        }
+    }
+
+    fn switch_to_cli_locked(&mut self, err: &anyhow::Error) -> Result<bool> {
+        if matches!(self.backend, Backend::Cli { .. }) {
+            return Ok(false);
+        }
+
+        let Some(bus) = find_ddcutil_bus_by_identifier(&self.identifier)? else {
+            return Ok(false);
+        };
+
+        let (_, max_brightness) = cli_get_brightness(bus)?;
+        log::warn!(
+            "Direct DDC access failed for '{}': {:?}. Switching to ddcutil CLI on bus {}.",
+            self.identifier,
+            err,
+            bus
+        );
+        self.backend = Backend::Cli { bus };
+        self.max_brightness = max_brightness;
+        Ok(true)
     }
 }
 
@@ -89,18 +202,18 @@ fn retry_ddc<T, F>(operation: &str, mut action: F) -> Result<T>
 where
     F: FnMut() -> Result<T>,
 {
-    for attempt in 1..=DDC_RETRIES {
+    for attempt in 1..=DDC_DIRECT_RETRIES {
         match action() {
             Ok(result) => return Ok(result),
-            Err(err) if attempt < DDC_RETRIES => {
+            Err(err) if attempt < DDC_DIRECT_RETRIES => {
                 log::debug!(
                     "Failed to {} over direct DDC (attempt {}/{}): {:?}",
                     operation,
                     attempt,
-                    DDC_RETRIES,
+                    DDC_DIRECT_RETRIES,
                     err
                 );
-                thread::sleep(Duration::from_millis(DDC_RETRY_SLEEP_MS));
+                thread::sleep(Duration::from_millis(DDC_DIRECT_RETRY_SLEEP_MS));
             }
             Err(err) => return Err(err),
         }
@@ -109,7 +222,235 @@ where
     unreachable!("retry loop always returns before falling through")
 }
 
-fn find_display_by_name(name: &str, check_caps: bool) -> Option<Display> {
+fn cli_get_brightness(bus: u32) -> Result<(u64, u64)> {
+    let bus = bus.to_string();
+    let stdout = retry_cli("read brightness via ddcutil CLI", || {
+        run_ddcutil(&["--bus", bus.as_str(), "getvcp", "10", "--terse"])
+    })?;
+
+    parse_ddcutil_getvcp_output(&stdout)
+}
+
+fn cli_set_brightness(bus: u32, value: u64) -> Result<()> {
+    let bus_arg = bus.to_string();
+    let value_arg = value.to_string();
+
+    if let Err(err) = retry_cli("set brightness via ddcutil CLI", || {
+        run_ddcutil(&[
+            "--bus",
+            bus_arg.as_str(),
+            "setvcp",
+            "10",
+            value_arg.as_str(),
+            "--noverify",
+        ])
+        .map(|_| ())
+    }) {
+        // Some monitors apply the value but still make ddcutil exit non-zero.
+        if cli_get_brightness(bus)
+            .map(|(current, _)| current == value)
+            .unwrap_or(false)
+        {
+            log::debug!(
+                "ddcutil setvcp reported an error on bus {}, but brightness is already {}.",
+                bus,
+                value
+            );
+            return Ok(());
+        }
+
+        return Err(err.context(format!(
+            "ddcutil setvcp failed on bus {} while setting brightness to {}",
+            bus, value
+        )));
+    }
+
+    Ok(())
+}
+
+fn retry_cli<T, F>(operation: &str, mut action: F) -> Result<T>
+where
+    F: FnMut() -> Result<T>,
+{
+    for attempt in 1..=DDC_CLI_RETRIES {
+        match action() {
+            Ok(result) => return Ok(result),
+            Err(err) if attempt < DDC_CLI_RETRIES => {
+                log::debug!(
+                    "Failed to {} (attempt {}/{}): {:?}",
+                    operation,
+                    attempt,
+                    DDC_CLI_RETRIES,
+                    err
+                );
+                thread::sleep(Duration::from_millis(DDC_CLI_RETRY_SLEEP_MS));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!("retry loop always returns before falling through")
+}
+
+fn run_ddcutil(args: &[&str]) -> Result<String> {
+    let output = Command::new("ddcutil")
+        .args(args)
+        .output()
+        .with_context(|| format!("Unable to execute ddcutil {}", args.iter().join(" ")))?;
+
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let details = match (stdout.is_empty(), stderr.is_empty()) {
+        (false, false) => format!(" stdout: {} stderr: {}", stdout, stderr),
+        (false, true) => format!(" stdout: {}", stdout),
+        (true, false) => format!(" stderr: {}", stderr),
+        (true, true) => " no output".to_string(),
+    };
+    let exit_status = output
+        .status
+        .code()
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "terminated by signal".to_string());
+
+    Err(anyhow!(
+        "ddcutil {} failed with status {}.{}",
+        args.iter().join(" "),
+        exit_status,
+        details
+    ))
+}
+
+fn find_ddcutil_bus_by_identifier(identifier: &str) -> Result<Option<u32>> {
+    let output = Command::new("ddcutil")
+        .args(["detect", "--terse"])
+        .output()
+        .context("Unable to execute ddcutil detect")?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "ddcutil detect failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    Ok(
+        parse_ddcutil_detect_output(&String::from_utf8_lossy(&output.stdout))?
+            .into_iter()
+            .find_map(|display| display.monitor.contains(identifier).then_some(display.bus)),
+    )
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CliDisplay {
+    bus: u32,
+    monitor: String,
+}
+
+fn parse_ddcutil_detect_output(output: &str) -> Result<Vec<CliDisplay>> {
+    let mut displays = Vec::new();
+    let mut current_bus = None;
+    let mut current_monitor = None;
+    let mut current_valid = true;
+
+    for line in output.lines() {
+        let line = line.trim();
+
+        if line.is_empty() || line.starts_with("Display ") {
+            push_cli_display(
+                &mut displays,
+                &mut current_bus,
+                &mut current_monitor,
+                current_valid,
+            );
+            current_valid = true;
+            continue;
+        }
+
+        if line == "Invalid display" {
+            push_cli_display(
+                &mut displays,
+                &mut current_bus,
+                &mut current_monitor,
+                current_valid,
+            );
+            current_valid = false;
+            continue;
+        }
+
+        if let Some(bus) = line.strip_prefix("I2C bus:") {
+            current_bus = Some(parse_bus_number(bus.trim())?);
+            continue;
+        }
+
+        if let Some(monitor) = line.strip_prefix("Monitor:") {
+            current_monitor = Some(monitor.trim().to_string());
+        }
+    }
+
+    push_cli_display(
+        &mut displays,
+        &mut current_bus,
+        &mut current_monitor,
+        current_valid,
+    );
+    Ok(displays)
+}
+
+fn push_cli_display(
+    displays: &mut Vec<CliDisplay>,
+    current_bus: &mut Option<u32>,
+    current_monitor: &mut Option<String>,
+    current_valid: bool,
+) {
+    let display = current_bus.take().zip(current_monitor.take());
+
+    if let (true, Some((bus, monitor))) = (current_valid, display) {
+        displays.push(CliDisplay { bus, monitor });
+    }
+}
+
+fn parse_bus_number(bus: &str) -> Result<u32> {
+    bus.rsplit('-')
+        .next()
+        .ok_or_else(|| anyhow!("Unable to parse ddcutil bus '{}': missing bus suffix", bus))?
+        .parse()
+        .context("Unable to parse ddcutil bus number")
+}
+
+fn parse_ddcutil_getvcp_output(output: &str) -> Result<(u64, u64)> {
+    let line = output
+        .lines()
+        .find(|line| line.trim_start().starts_with("VCP "))
+        .ok_or_else(|| {
+            anyhow!(
+                "ddcutil getvcp returned unexpected output: {}",
+                output.trim()
+            )
+        })?;
+    let parts = line.split_whitespace().collect_vec();
+
+    if parts.len() < 5 {
+        return Err(anyhow!(
+            "ddcutil getvcp returned unexpected terse output: {}",
+            line
+        ));
+    }
+
+    let current = parts[3]
+        .parse::<u64>()
+        .context("Unable to parse current brightness from ddcutil getvcp output")?;
+    let maximum = parts[4]
+        .parse::<u64>()
+        .context("Unable to parse max brightness from ddcutil getvcp output")?;
+
+    Ok((current, maximum))
+}
+
+fn find_display_by_identifier(identifier: &str, check_caps: bool) -> Option<Display> {
     let displays = ddc_hi::Display::enumerate()
         .into_iter()
         .filter_map(|mut display| {
@@ -139,15 +480,51 @@ fn find_display_by_name(name: &str, check_caps: bool) -> Option<Display> {
 
     displays.into_iter().find_map(|(merged, display)| {
         merged
-            .contains(name)
+            .contains(identifier)
             .then(|| {
                 log::debug!(
                     "Using display '{}' for config '{}' (check_caps={})",
                     merged,
-                    name,
+                    identifier,
                     check_caps
                 );
             })
             .map(|_| display)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ddcutil_detect_output() -> Result<()> {
+        let output = r#"
+Invalid display
+   I2C bus:          /dev/i2c-4
+   DRM connector:    card1-eDP-1
+   Monitor:          AUO::
+
+Display 1
+   I2C bus:          /dev/i2c-12
+   DRM connector:    card0-HDMI-A-3
+   Monitor:          GSM:LG ULTRAWIDE:504AZER5F964
+"#;
+
+        assert_eq!(
+            parse_ddcutil_detect_output(output)?,
+            vec![CliDisplay {
+                bus: 12,
+                monitor: "GSM:LG ULTRAWIDE:504AZER5F964".to_string(),
+            }]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_ddcutil_getvcp_output() -> Result<()> {
+        assert_eq!(parse_ddcutil_getvcp_output("VCP 10 C 27 100")?, (27, 100));
+        Ok(())
+    }
 }

--- a/src/brightness/ddcutil.rs
+++ b/src/brightness/ddcutil.rs
@@ -3,12 +3,18 @@ use ddc_hi::{Ddc, Display, FeatureCode};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use smol::lock::Mutex;
+use std::thread;
+use std::time::Duration;
 
 lazy_static! {
     static ref DDC_MUTEX: Mutex<()> = Mutex::new(());
 }
 
 const DDC_BRIGHTNESS_FEATURE: FeatureCode = 0x10;
+const DDC_WAITING_SLEEP_MS: u64 = 500;
+const DDC_TRANSITION_STEP_MS: u64 = 50;
+const DDC_RETRIES: usize = 3;
+const DDC_RETRY_SLEEP_MS: u64 = 40;
 
 pub struct DdcUtil {
     display: Mutex<Display>,
@@ -21,7 +27,7 @@ impl DdcUtil {
         let mut display = find_display_by_name(name, true)
             .or_else(|| find_display_by_name(name, false))
             .ok_or(anyhow!("Unable to find display"))?;
-        let max_brightness = get_max_brightness(&mut display)?;
+        let max_brightness = get_max_brightness_with_retry(&mut display)?;
 
         Ok(Self {
             display: Mutex::new(display),
@@ -32,22 +38,21 @@ impl DdcUtil {
 
     pub async fn get(&mut self) -> Result<u64> {
         let _lock = DDC_MUTEX.lock().await;
-        Ok(self
-            .display
-            .get_mut()
-            .handle
-            .get_vcp_feature(DDC_BRIGHTNESS_FEATURE)?
-            .value() as u64)
+        get_brightness_with_retry(self.display.get_mut())
     }
 
     pub async fn set(&mut self, value: u64) -> Result<u64> {
         let _lock = DDC_MUTEX.lock().await;
         let value = value.clamp(self.min_brightness, self.max_brightness);
-        self.display
-            .get_mut()
-            .handle
-            .set_vcp_feature(DDC_BRIGHTNESS_FEATURE, value as u16)?;
-        Ok(value)
+        set_brightness_with_retry(self.display.get_mut(), value)
+    }
+
+    pub fn waiting_sleep_ms(&self) -> u64 {
+        DDC_WAITING_SLEEP_MS
+    }
+
+    pub fn transition_step_ms(&self) -> u64 {
+        DDC_TRANSITION_STEP_MS
     }
 }
 
@@ -56,6 +61,52 @@ fn get_max_brightness(display: &mut Display) -> Result<u64> {
         .handle
         .get_vcp_feature(DDC_BRIGHTNESS_FEATURE)?
         .maximum() as u64)
+}
+
+fn get_max_brightness_with_retry(display: &mut Display) -> Result<u64> {
+    retry_ddc("read max brightness", || get_max_brightness(display))
+}
+
+fn get_brightness_with_retry(display: &mut Display) -> Result<u64> {
+    retry_ddc("read brightness", || {
+        Ok(display
+            .handle
+            .get_vcp_feature(DDC_BRIGHTNESS_FEATURE)?
+            .value() as u64)
+    })
+}
+
+fn set_brightness_with_retry(display: &mut Display, value: u64) -> Result<u64> {
+    retry_ddc("set brightness", || {
+        display
+            .handle
+            .set_vcp_feature(DDC_BRIGHTNESS_FEATURE, value as u16)?;
+        Ok(value)
+    })
+}
+
+fn retry_ddc<T, F>(operation: &str, mut action: F) -> Result<T>
+where
+    F: FnMut() -> Result<T>,
+{
+    for attempt in 1..=DDC_RETRIES {
+        match action() {
+            Ok(result) => return Ok(result),
+            Err(err) if attempt < DDC_RETRIES => {
+                log::debug!(
+                    "Failed to {} over direct DDC (attempt {}/{}): {:?}",
+                    operation,
+                    attempt,
+                    DDC_RETRIES,
+                    err
+                );
+                thread::sleep(Duration::from_millis(DDC_RETRY_SLEEP_MS));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!("retry loop always returns before falling through")
 }
 
 fn find_display_by_name(name: &str, check_caps: bool) -> Option<Display> {

--- a/src/brightness/mod.rs
+++ b/src/brightness/mod.rs
@@ -42,4 +42,24 @@ impl Brightness {
             }
         }
     }
+
+    pub fn transition_step_ms(&self) -> u64 {
+        match self {
+            Brightness::DdcUtil(b) => b.transition_step_ms(),
+            Brightness::Backlight(_) => 1,
+
+            #[cfg(test)]
+            Brightness::Mock { .. } => 1,
+        }
+    }
+
+    pub fn waiting_sleep_ms(&self) -> u64 {
+        match self {
+            Brightness::DdcUtil(b) => b.waiting_sleep_ms(),
+            Brightness::Backlight(_) => 100,
+
+            #[cfg(test)]
+            Brightness::Mock { .. } => 100,
+        }
+    }
 }

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -62,6 +62,7 @@ pub struct BacklightOutput {
 #[derive(Debug, Clone)]
 pub struct DdcUtilOutput {
     pub name: String,
+    pub identifier: String,
     pub capturer: Capturer,
     pub min_brightness: u64,
     pub predictor: Predictor,

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -63,6 +63,7 @@ pub struct BacklightOutput {
 #[derive(Deserialize, Debug)]
 pub struct DdcUtilOutput {
     pub name: String,
+    pub identifier: Option<String>,
     pub capturer: Option<Capturer>,
     pub predictor: Option<Predictor>,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -58,13 +58,17 @@ fn parse() -> Result<app::Config, toml::de::Error> {
         .and_then(|cfg_path| fs::read_to_string(cfg_path).ok())
         .unwrap_or_else(|| include_str!("../../config.toml").to_string());
 
+    parse_config_str(&file_config)
+}
+
+fn parse_config_str(file_config: &str) -> Result<app::Config, toml::de::Error> {
     let parse_als_thresholds = |t: HashMap<String, String>| -> HashMap<u64, String> {
         t.into_iter()
             .map(|(k, v)| (k.parse().unwrap(), v))
             .collect()
     };
 
-    toml::from_str(&file_config).map(|file_config: file::Config| app::Config {
+    toml::from_str(file_config).map(|file_config: file::Config| app::Config {
         output: file_config
             .output
             .backlight
@@ -79,8 +83,10 @@ fn parse() -> Result<app::Config, toml::de::Error> {
                 })
             })
             .chain(file_config.output.ddcutil.into_iter().map(|o| {
+                let identifier = o.identifier.clone().unwrap_or_else(|| o.name.clone());
                 app::Output::DdcUtil(app::DdcUtilOutput {
                     name: o.name,
+                    identifier,
                     min_brightness: 1,
                     capturer: match_capturer(o.capturer.unwrap_or_default()),
                     predictor: match_predictor(o.predictor.unwrap_or_default()),
@@ -128,5 +134,79 @@ fn validate(config: app::Config) -> Result<app::Config> {
         (0, _) => Err(anyhow!("No output or keyboard configured")),
         (_, false) => Err(anyhow!("Names of all outputs and keyboards are not unique")),
         _ => Ok(config),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ddc_identifier_defaults_to_output_name() {
+        let config = parse_config_str(
+            r#"
+[als.none]
+
+[[output.backlight]]
+name = "panel"
+path = "/sys/class/backlight/panel"
+capturer = "none"
+
+[[output.ddcutil]]
+name = "HDMI-A-3"
+capturer = "none"
+"#,
+        )
+        .unwrap();
+
+        match &config.output[0] {
+            app::Output::Backlight(output) => {
+                assert_eq!("panel", output.name);
+            }
+            _ => unreachable!(),
+        }
+
+        match &config.output[1] {
+            app::Output::DdcUtil(output) => {
+                assert_eq!("HDMI-A-3", output.name);
+                assert_eq!("HDMI-A-3", output.identifier);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn test_ddc_identifier_can_be_configured_separately() {
+        let config = parse_config_str(
+            r#"
+[als.none]
+
+[[output.backlight]]
+name = "panel"
+path = "/sys/class/backlight/panel"
+capturer = "none"
+
+[[output.ddcutil]]
+name = "HDMI-A-3"
+identifier = "serial-123"
+capturer = "none"
+"#,
+        )
+        .unwrap();
+
+        match &config.output[0] {
+            app::Output::Backlight(output) => {
+                assert_eq!("panel", output.name);
+            }
+            _ => unreachable!(),
+        }
+
+        match &config.output[1] {
+            app::Output::DdcUtil(output) => {
+                assert_eq!("HDMI-A-3", output.name);
+                assert_eq!("serial-123", output.identifier);
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/src/frame/capturer/wayland.rs
+++ b/src/frame/capturer/wayland.rs
@@ -110,7 +110,7 @@ impl Capturer {
 
         if self.output.is_none() {
             log::warn!(
-                "Unable to match any Wayland output for config '{}'. Adjust the output name to a substring of the compositor output description. For DDC outputs, keep name for capture matching and use identifier for brightness control if needed.",
+                "Unable to match config '{}' to any Wayland output.",
                 output_name,
             );
         }

--- a/src/frame/capturer/wayland.rs
+++ b/src/frame/capturer/wayland.rs
@@ -108,6 +108,13 @@ impl Capturer {
             .roundtrip(self)
             .expect("Unable to perform 2nd initial roundtrip");
 
+        if self.output.is_none() {
+            log::warn!(
+                "Unable to match any Wayland output for config '{}'. Adjust the output name to a substring of the compositor output description. For DDC outputs, keep name for capture matching and use identifier for brightness control if needed.",
+                output_name,
+            );
+        }
+
         let protocol_to_use = match self.protocol {
             WaylandProtocol::ExtImageCopyCaptureV1 => {
                 if self.img_copy_capture_manager.is_none() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ async fn main() {
                             .map(brightness::Brightness::Backlight)
                     }
                     config::Output::DdcUtil(cfg) => {
-                        brightness::DdcUtil::new(&cfg.name, cfg.min_brightness)
+                        brightness::DdcUtil::new(&cfg.identifier, cfg.min_brightness)
                             .map(brightness::Brightness::DdcUtil)
                     }
                 };


### PR DESCRIPTION
This change improves external monitor support in two related areas: it separates the identifier used for brightness control from the identifier used for Wayland output capture, and it makes DDC brightness control more tolerant of flaky direct DDC access.

- Add `capture_name` as an optional config field for `backlight` and `ddcutil` outputs.
- Keep `name` as the brightness-device identity while using `capture_name` only for Wayland output matching.
- Make DDC control more resilient by slowing DDC transitions, retrying direct DDC reads/writes, and falling back to the `ddcutil` CLI when raw DDC access is unreliable.
- Add a clear warning when no Wayland output matches a configured capture target.

The changes are split into three commits so the config/capture-name part, the direct DDC retry/timing changes, and the CLI fallback can be reviewed separately. I can split this into separate PRs if preferred.

## Problem

External DDC monitors can require two different identifiers:

- The DDC layer may only be reliably identifiable by serial number.
- The Wayland compositor may expose the same monitor under a connector- or model-based description.

Before this change, `wluma` used a single `name` field for both concerns. That created a mismatch for some external monitors: DDC brightness control could work while frame capture never matched the intended output, which prevented the adaptive predictor from learning or applying brightness changes correctly.

The direct DDC path can also be unreliable on some monitors, producing errors such as `invalid DDC/CI length` or `Expected DDC/CI length bit` even when the standalone `ddcutil` CLI can still read or set brightness. Those failures can make wluma skip the display at startup or repeatedly fail brightness reads during normal operation.

## Solution

### Configuration

`capture_name` is now available for both output types:

- If omitted, it defaults to `name`.
- If set, it is passed only to the Wayland capturer.
- `name` remains the identifier for brightness control and predictor persistence.

### Runtime behavior

- `main.rs` now passes `name` to brightness backends and `capture_name` to frame capture.
- The Wayland capturer logs a warning when it cannot match any compositor output.
- The DDC backend now:
  - uses slower transition and polling timings for external DDC outputs,
  - retries transient failures in the direct DDC path,
  - falls back to the `ddcutil` CLI when direct DDC becomes unreliable,
  - retries CLI operations and reports full command failure details when the CLI path fails.

## Related Issues

- May help with #114 by retrying direct DDC access and falling back to the `ddcutil` CLI when direct DDC reads or writes fail.
- May partially address #160 for startup-time transient DDC/CI failures, as long as the `ddcutil` CLI can detect and read the monitor after direct DDC fails.

## Validation

Automated:

- `nix develop -c cargo fmt --check`
- `nix develop -c cargo test`
  - Result: `37 passed`
- `nix develop -c cargo clippy --all-targets -- -D warnings`

Manual:

- Verified that the external monitor can be matched through Wayland using `capture_name`.
- Verified that DDC fallback can switch from direct access to `ddcutil` CLI on unstable monitors.
- Verified that the adaptive controller starts learning entries for the external output once capture matching succeeds.

## Risks And Follow-Ups

- CLI fallback still depends on `ddcutil` being installed and available in `PATH`.
- If neither direct DDC nor the `ddcutil` CLI can detect/read a monitor during startup, wluma will still skip that output.
- CLI mode is intentionally slower than direct DDC mode to reduce transient bus errors.
