### PR TITLE
Scale brightness transition steps to the backlight's range

### DIFF
--- a/src/brightness/backlight.rs
+++ b/src/brightness/backlight.rs
@@ -130,6 +130,10 @@ impl Backlight {
         }
     }
 
+    pub fn min_step(&self) -> u64 {
+        (self.max_brightness / 256).max(1)
+    }
+
     pub async fn set(&mut self, value: u64) -> Result<u64> {
         let value = value.clamp(self.min_brightness, self.max_brightness);
 

--- a/src/brightness/controller.rs
+++ b/src/brightness/controller.rs
@@ -90,15 +90,19 @@ impl Controller {
     fn update_target(&mut self, desired: u64) {
         match (&self.target, self.current) {
             (Some(old_target), _) if old_target.desired == desired => (),
-            (_, Some(current)) if desired == current => (),
+            (_, Some(current)) if desired.abs_diff(current) < self.brightness.min_step() => (),
             (_, Some(current)) => {
                 let max_transition_steps = TRANSITION_MAX_MS
                     .div_ceil(self.brightness.transition_step_ms())
                     .max(1);
+                let step_size = desired
+                    .abs_diff(current)
+                    .div_ceil(max_transition_steps)
+                    .max(self.brightness.min_step()) as i64;
                 let step = if desired > current {
-                    (desired - current).div_ceil(max_transition_steps) as i64
+                    step_size
                 } else {
-                    -((current - desired).div_ceil(max_transition_steps) as i64)
+                    -step_size
                 };
                 self.target = Some(Target { desired, step });
             }
@@ -112,7 +116,15 @@ impl Controller {
                 if target.reached(current) {
                     self.target = None;
                 } else {
-                    let new_value = current.saturating_add_signed(target.step);
+                    let new_value = if target.step > 0 {
+                        current
+                            .saturating_add_signed(target.step)
+                            .min(target.desired)
+                    } else {
+                        current
+                            .saturating_add_signed(target.step)
+                            .max(target.desired)
+                    };
                     match self.brightness.set(new_value).await {
                         Ok(set_value) => {
                             if set_value == current {
@@ -148,12 +160,20 @@ mod tests {
     }
 
     fn brightness_mock(get: Vec<u64>, set: Vec<u64>) -> Brightness {
-        Brightness::Mock { get, set }
+        Brightness::Mock {
+            get,
+            set,
+            min_step: 1,
+        }
+    }
+
+    fn brightness_mock_with_min_step(get: Vec<u64>, set: Vec<u64>, min_step: u64) -> Brightness {
+        Brightness::Mock { get, set, min_step }
     }
 
     fn is_brightness_spent(mock: &Brightness) -> bool {
         match mock {
-            Brightness::Mock { get, set } => get.is_empty() && set.is_empty(),
+            Brightness::Mock { get, set, .. } => get.is_empty() && set.is_empty(),
             _ => unreachable!(),
         }
     }
@@ -278,6 +298,40 @@ mod tests {
             controller.update_target(desired);
             assert_eq!(Some(target(desired, expected_step)), controller.target);
         }
+    }
+
+    #[test]
+    fn test_update_target_ignore_when_desired_within_min_step_of_current() {
+        let old_target = Some(target(10000, -20));
+        let (mut controller, _, _) = setup(brightness_mock_with_min_step(vec![], vec![], 100));
+        controller.target = old_target;
+        controller.current = Some(10000);
+
+        controller.update_target(10099);
+
+        assert_eq!(old_target, controller.target);
+    }
+
+    #[test]
+    fn test_update_target_step_is_at_least_min_step() {
+        let (mut controller, _, _) = setup(brightness_mock_with_min_step(vec![], vec![], 100));
+        controller.current = Some(10000);
+
+        controller.update_target(10150);
+
+        assert_eq!(Some(target(10150, 100)), controller.target);
+    }
+
+    #[apply(test!)]
+    async fn test_transition_does_not_overshoot_desired() {
+        let (mut controller, _, _) = setup(brightness_mock_with_min_step(vec![], vec![10150], 100));
+        controller.current = Some(10100);
+        controller.target = Some(target(10150, 100));
+
+        controller.transition().await;
+
+        assert_eq!(Some(10150), controller.current);
+        assert!(is_brightness_spent(&controller.brightness));
     }
 
     #[apply(test!)]

--- a/src/brightness/controller.rs
+++ b/src/brightness/controller.rs
@@ -21,6 +21,7 @@ pub struct Controller {
 struct Target {
     desired: u64,
     step: i64,
+    sleep_ms: u64,
 }
 
 impl Target {
@@ -95,16 +96,32 @@ impl Controller {
                 let max_transition_steps = TRANSITION_MAX_MS
                     .div_ceil(self.brightness.transition_step_ms())
                     .max(1);
-                let step_size = desired
-                    .abs_diff(current)
-                    .div_ceil(max_transition_steps)
-                    .max(self.brightness.min_step()) as i64;
-                let step = if desired > current {
-                    step_size
+                let delta = desired.abs_diff(current);
+                let min_step = self.brightness.min_step();
+                // When min_step binds, keep the transition duration by
+                // stretching the interval instead of shortening the ramp.
+                let (step_size, sleep_ms) = if delta.div_ceil(max_transition_steps) >= min_step {
+                    (
+                        delta.div_ceil(max_transition_steps),
+                        self.brightness.transition_step_ms(),
+                    )
                 } else {
-                    -step_size
+                    let steps = delta.div_ceil(min_step).max(1);
+                    (
+                        min_step,
+                        (TRANSITION_MAX_MS / steps).max(self.brightness.transition_step_ms()),
+                    )
                 };
-                self.target = Some(Target { desired, step });
+                let step = if desired > current {
+                    step_size as i64
+                } else {
+                    -(step_size as i64)
+                };
+                self.target = Some(Target {
+                    desired,
+                    step,
+                    sleep_ms,
+                });
             }
             _ => unreachable!("Current value cannot be None at this point"),
         };
@@ -138,7 +155,7 @@ impl Controller {
                             err
                         ),
                     };
-                    thread::sleep(Duration::from_millis(self.brightness.transition_step_ms()));
+                    thread::sleep(Duration::from_millis(target.sleep_ms));
                 }
             }
             _ => unreachable!("Current and target values cannot be None at this point"),
@@ -156,7 +173,19 @@ mod tests {
 
     // Intentionally not in main code to prevent confusing fields by accident
     fn target(desired: u64, step: i64) -> Target {
-        Target { desired, step }
+        Target {
+            desired,
+            step,
+            sleep_ms: 1,
+        }
+    }
+
+    fn target_with_sleep(desired: u64, step: i64, sleep_ms: u64) -> Target {
+        Target {
+            desired,
+            step,
+            sleep_ms,
+        }
     }
 
     fn brightness_mock(get: Vec<u64>, set: Vec<u64>) -> Brightness {
@@ -313,13 +342,17 @@ mod tests {
     }
 
     #[test]
-    fn test_update_target_step_is_at_least_min_step() {
+    fn test_update_target_step_is_at_least_min_step_with_stretched_interval() {
         let (mut controller, _, _) = setup(brightness_mock_with_min_step(vec![], vec![], 100));
         controller.current = Some(10000);
 
+        // min_step binds: 2 steps of 100, spread over the transition duration
         controller.update_target(10150);
+        assert_eq!(Some(target_with_sleep(10150, 100, 100)), controller.target);
 
-        assert_eq!(Some(target(10150, 100)), controller.target);
+        // min_step does not bind: step and interval as without min_step
+        controller.update_target(40000);
+        assert_eq!(Some(target_with_sleep(40000, 150, 1)), controller.target);
     }
 
     #[apply(test!)]

--- a/src/brightness/controller.rs
+++ b/src/brightness/controller.rs
@@ -109,7 +109,9 @@ impl Controller {
                     let steps = delta.div_ceil(min_step).max(1);
                     (
                         min_step,
-                        (TRANSITION_MAX_MS / steps).max(self.brightness.transition_step_ms()),
+                        TRANSITION_MAX_MS
+                            .div_ceil(steps)
+                            .max(self.brightness.transition_step_ms()),
                     )
                 };
                 let step = if desired > current {

--- a/src/brightness/mod.rs
+++ b/src/brightness/mod.rs
@@ -16,6 +16,7 @@ pub enum Brightness {
     Mock {
         get: Vec<u64>,
         set: Vec<u64>,
+        min_step: u64,
     },
 }
 
@@ -40,6 +41,16 @@ impl Brightness {
                 assert_eq!(set.remove(0), value);
                 Ok(value)
             }
+        }
+    }
+
+    pub fn min_step(&self) -> u64 {
+        match self {
+            Brightness::DdcUtil(_) => 1,
+            Brightness::Backlight(b) => b.min_step(),
+
+            #[cfg(test)]
+            Brightness::Mock { min_step, .. } => *min_step,
         }
     }
 


### PR DESCRIPTION
## Problem

On sysfs backlights with a large `max_brightness`, wluma writes to the brightness file essentially continuously. My laptop (Framework 16, amdgpu, `max_brightness` = 62194) sees **~540 sysfs writes per second** in steady state: prediction noise of a few units (±0.003% of the range) starts a new transition, and since any delta ≤ 200 units gets `step = 1` with a 1 ms step interval, wluma crawls unit-by-unit toward a target that never stops moving.

This is more than log noise. Every write emits a kernel uevent, and systemd rebroadcasts each one on the system D-Bus as `PropertiesChanged` for the device unit and its `systemd-backlight@` service (~2,200 signals/s measured with `dbus-monitor --system`). Busy peers subscribed to broadcasts can't drain their queues and get force-disconnected by dbus-broker:

```
dbus-broker[996]: Peer :1.972 is being disconnected as it does not have the resources to receive a signal it subscribed to.
```

In my case that killed a running Steam game and Steam itself mid-session. Devices with a small brightness range (100–255) never see this because prediction noise rounds to zero units — which is probably why it has gone unnoticed.

## Fix

- Add `min_step()` — `max_brightness / 256`, floor 1 — to `Backlight`, exposed via `Brightness`.
- Use it as a deadband in `update_target`: predictions within `min_step` of the current value are ignored (generalizes the existing `desired == current` check).
- Use it as the minimum transition step, so a full-range transition is at most ~256 writes.
- When `min_step` binds, stretch the per-step interval so the ramp still spans `TRANSITION_MAX_MS` — fewer writes, same transition duration, so transitions stay visually smooth instead of completing in a few milliseconds.
- Clamp transition writes to the target so the enlarged step lands exactly on `desired` instead of overshooting.

Devices with `max_brightness` ≤ 256 get `min_step` = 1, which preserves the previous behaviour exactly — all existing tests pass unchanged. DDC/CI outputs are unaffected (`min_step` = 1 on their 0–100 range).

## Results (Framework 16, amdgpu, max 62194)

| | backlight uevents |
|---|---|
| before | ~540/s sustained |
| after | ~2.5/s (real adjustments only) |

Auto-adjustment still works. Measured a forced dim/re-brighten cycle: ~70 evenly spaced steps spanning the full transition window per direction.