### PR TITLE
Fixed EDID fallback 4-byte serial to be properly formatted hex

### DIFF
--- a/src/brightness/ddcutil.rs
+++ b/src/brightness/ddcutil.rs
@@ -328,7 +328,7 @@ fn run_ddcutil(args: &[&str]) -> Result<String> {
 
 fn find_ddcutil_bus_by_identifier(identifier: &str) -> Result<Option<u32>> {
     let output = Command::new("ddcutil")
-        .args(["detect", "--terse"])
+        .arg("detect")
         .output()
         .context("Unable to execute ddcutil detect")?;
 
@@ -342,30 +342,40 @@ fn find_ddcutil_bus_by_identifier(identifier: &str) -> Result<Option<u32>> {
     Ok(
         parse_ddcutil_detect_output(&String::from_utf8_lossy(&output.stdout))?
             .into_iter()
-            .find_map(|display| display.monitor.contains(identifier).then_some(display.bus)),
+            .find_map(|display| display.matches(identifier).then_some(display.bus)),
     )
 }
 
 #[derive(Debug, PartialEq, Eq)]
 struct CliDisplay {
     bus: u32,
-    monitor: String,
+    identifiers: String,
+}
+
+impl CliDisplay {
+    fn matches(&self, identifier: &str) -> bool {
+        self.identifiers.contains(identifier)
+    }
 }
 
 fn parse_ddcutil_detect_output(output: &str) -> Result<Vec<CliDisplay>> {
     let mut displays = Vec::new();
     let mut current_bus = None;
-    let mut current_monitor = None;
+    let mut current_identifiers = Vec::new();
     let mut current_valid = true;
 
     for line in output.lines() {
         let line = line.trim();
 
-        if line.is_empty() || line.starts_with("Display ") {
+        if line.is_empty() {
+            continue;
+        }
+
+        if line.starts_with("Display ") {
             push_cli_display(
                 &mut displays,
                 &mut current_bus,
-                &mut current_monitor,
+                &mut current_identifiers,
                 current_valid,
             );
             current_valid = true;
@@ -376,7 +386,7 @@ fn parse_ddcutil_detect_output(output: &str) -> Result<Vec<CliDisplay>> {
             push_cli_display(
                 &mut displays,
                 &mut current_bus,
-                &mut current_monitor,
+                &mut current_identifiers,
                 current_valid,
             );
             current_valid = false;
@@ -388,15 +398,24 @@ fn parse_ddcutil_detect_output(output: &str) -> Result<Vec<CliDisplay>> {
             continue;
         }
 
-        if let Some(monitor) = line.strip_prefix("Monitor:") {
-            current_monitor = Some(monitor.trim().to_string());
+        for prefix in [
+            "Monitor:",
+            "Mfg id:",
+            "Model:",
+            "Serial number:",
+            "Binary serial number:",
+        ] {
+            if let Some(value) = line.strip_prefix(prefix) {
+                current_identifiers.push(value.trim().to_string());
+                break;
+            }
         }
     }
 
     push_cli_display(
         &mut displays,
         &mut current_bus,
-        &mut current_monitor,
+        &mut current_identifiers,
         current_valid,
     );
     Ok(displays)
@@ -405,13 +424,14 @@ fn parse_ddcutil_detect_output(output: &str) -> Result<Vec<CliDisplay>> {
 fn push_cli_display(
     displays: &mut Vec<CliDisplay>,
     current_bus: &mut Option<u32>,
-    current_monitor: &mut Option<String>,
+    current_identifiers: &mut Vec<String>,
     current_valid: bool,
 ) {
-    let display = current_bus.take().zip(current_monitor.take());
+    let bus = current_bus.take();
+    let identifiers = std::mem::take(current_identifiers).join(" ");
 
-    if let (true, Some((bus, monitor))) = (current_valid, display) {
-        displays.push(CliDisplay { bus, monitor });
+    if let (true, Some(bus), false) = (current_valid, bus, identifiers.is_empty()) {
+        displays.push(CliDisplay { bus, identifiers });
     }
 }
 
@@ -471,7 +491,7 @@ fn find_display_by_identifier(identifier: &str, check_caps: bool) -> Option<Disp
                     display
                         .info
                         .serial
-                        .map(|value| value.to_string())
+                        .map(binary_serial_identifiers)
                         .unwrap_or_default()
                 );
                 (merged, display)
@@ -500,9 +520,21 @@ fn find_display_by_identifier(identifier: &str, check_caps: bool) -> Option<Disp
     })
 }
 
+fn binary_serial_identifiers(value: u32) -> String {
+    format!("{} {:#010x}", value, value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_binary_serial_identifiers() {
+        assert_eq!(
+            binary_serial_identifiers(0x1234abcd),
+            "305441741 0x1234abcd"
+        );
+    }
 
     #[test]
     fn test_parse_ddcutil_detect_output() -> Result<()> {
@@ -515,16 +547,24 @@ Invalid display
 Display 1
    I2C bus:          /dev/i2c-12
    DRM connector:    card0-HDMI-A-3
-   Monitor:          GSM:LG ULTRAWIDE:504AZER5F964
+   EDID synopsis:
+      Mfg id:               GSM
+      Model:                LG ULTRAWIDE
+      Serial number:        504AZER5F964
+      Binary serial number: 305441741 (0x1234abcd)
 "#;
 
+        let displays = parse_ddcutil_detect_output(output)?;
         assert_eq!(
-            parse_ddcutil_detect_output(output)?,
+            displays,
             vec![CliDisplay {
                 bus: 12,
-                monitor: "GSM:LG ULTRAWIDE:504AZER5F964".to_string(),
+                identifiers: "GSM LG ULTRAWIDE 504AZER5F964 305441741 (0x1234abcd)".to_string(),
             }]
         );
+        assert!(displays[0].matches("0x1234abcd"));
+        assert!(displays[0].matches("305441741"));
+        assert!(displays[0].matches("504AZER5F964"));
 
         Ok(())
     }

--- a/src/config/discovery.rs
+++ b/src/config/discovery.rs
@@ -189,7 +189,7 @@ fn display_identifier(display: &Display) -> Option<String> {
         .serial_number
         .clone()
         .filter(|value| !value.is_empty())
-        .or_else(|| display.info.serial.map(|value| value.to_string()))
+        .or_else(|| display.info.serial.map(|value| format!("{:#010x}", value)))
         .or_else(|| {
             display
                 .info


### PR DESCRIPTION
Changes
```
Unable to initialize DDC display '16843009' directly
```
to
```
Unable to initialize DDC display '0x01010101' directly
```
following e.g. `gdctl show` format.